### PR TITLE
Migrate lookahead from uint8 to uint32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docker_data/
 docs/reference/
 node_modules/
 npm-debug.log
+.idea

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -523,11 +523,14 @@ class HTTP extends Server {
     socket.hook('set filter', (...args) => {
       const valid = new Validator(args);
       const data = valid.buf(0);
+      const height = valid.i32(1, 0);
 
       if (!data)
         throw new Error('Invalid parameter.');
 
       socket.filter = BloomFilter.decode(data);
+      socket.filterUpdated = true;
+      socket.filterUpdatedHeight = height;
 
       return null;
     });
@@ -772,15 +775,30 @@ class HTTP extends Server {
    */
 
   async scan(socket, start) {
-    await this.node.scan(start, socket.filter, (entry, txs) => {
-      const block = entry.encode();
-      const raw = [];
+    try {
+      await this.node.scan(start, socket.filter, (entry, txs) => {
+        if (socket.filterUpdated) {
+          throw Error('filter updated');
+        }
 
-      for (const tx of txs)
-        raw.push(tx.encode());
+        const block = entry.encode();
+        const raw = [];
 
-      return socket.call('block rescan', block, raw);
-    });
+        for (const tx of txs)
+          raw.push(tx.encode());
+
+        return socket.call('block rescan', block, raw);
+      });
+    } catch (e) {
+      if (/filter updated/gi.test(e.message)) {
+        socket.filterUpdated = false;
+        return this.scan(socket, socket.filterUpdatedHeight - 1);
+      }
+
+      throw e;
+    }
+
+
     return null;
   }
 }

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -793,7 +793,7 @@ class Account extends bio.Struct {
    */
 
   static decode(wdb, data) {
-    return new this(wdb).decode(data);
+    return new this(wdb).decode(data || {});
   }
 
   /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -792,8 +792,8 @@ class Account extends bio.Struct {
    * @returns {Account}
    */
 
-  static decode(wdb, data) {
-    return new this(wdb).decode(data || {});
+  static decode(wdb, data, extra) {
+    return new this(wdb).decode(data , extra || {});
   }
 
   /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -761,7 +761,7 @@ class Account extends bio.Struct {
    * @returns {Object}
    */
 
-  read(br) {
+  read(br, extra) {
     const flags = br.readU8();
 
     this.initialized = (flags & 1) !== 0;
@@ -770,7 +770,7 @@ class Account extends bio.Struct {
     this.n = br.readU8();
     this.receiveDepth = br.readU32();
     this.changeDepth = br.readU32();
-    this.lookahead = br.readU32();
+    this.lookahead = extra.readU8 ? br.readU8() : br.readU32();
     this.accountKey = readKey(br);
 
     assert(this.type < Account.typesByVal.length);
@@ -794,6 +794,17 @@ class Account extends bio.Struct {
 
   static decode(wdb, data) {
     return new this(wdb).decode(data);
+  }
+
+  /**
+   * Decode account (U8 lookahead).
+   * @param {WalletDB} wdb
+   * @param {Buffer} data
+   * @returns {Account}
+   */
+
+  static decodeU8(wdb, data) {
+    return new this(wdb).decode(data, { readU8: true });
   }
 
   /**

--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -69,8 +69,10 @@ class WalletClient extends NodeClient {
     return super.sendClaim(claim.encode());
   }
 
-  async setFilter(filter) {
-    return super.setFilter(filter.encode());
+  async setFilter(filter, height) {
+    const filterBuf = filter.encode();
+    assert(Buffer.isBuffer(filterBuf));
+    return this.call('set filter', filterBuf, height);
   }
 
   async rescan(start) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -4151,17 +4151,18 @@ class Wallet extends EventEmitter {
    */
 
   async _add(tx, block) {
+    let derived = [];
     const details = await this.txdb.add(tx, block);
 
     if (details) {
-      const derived = await this.syncOutputDepth(tx);
+      derived = await this.syncOutputDepth(tx);
       if (derived.length > 0) {
         this.wdb.emit('address', this, derived);
         this.emit('address', derived);
       }
     }
 
-    return details;
+    return {details, derived};
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -196,6 +196,7 @@ class WalletDB extends EventEmitter {
       this.state.height,
       this.state.startHeight);
 
+    await this.migrateLookahead();
     await this.migrateChange();
 
     const wallet = await this.ensure({
@@ -249,6 +250,7 @@ class WalletDB extends EventEmitter {
 
         try {
           const account = Account.decodeU8(this, data);
+          account.wid = wid;
           account.accountIndex = accountIndex;
           account.name = name;
 
@@ -261,7 +263,7 @@ class WalletDB extends EventEmitter {
       }
     }
 
-    if (this.options.migrate === 1)
+    if (this.options.migrate >= 1)
       await b.write();
   }
 
@@ -300,7 +302,7 @@ class WalletDB extends EventEmitter {
       total += await wallet.migrateChange(b);
     }
 
-    if (this.options.migrate === 0 || total === 0)
+    if (this.options.migrate >= 0 || total === 0)
       await b.write();
 
     if (total === 0) {
@@ -308,7 +310,7 @@ class WalletDB extends EventEmitter {
       return;
     }
 
-    if (this.options.migrate === 0) {
+    if (this.options.migrate >= 0) {
       this.logger.warning('Regenerated %d change addresses.', total);
       this.logger.warning('Rescanning...');
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -238,20 +238,26 @@ class WalletDB extends EventEmitter {
     for (const wid of wids) {
       const accounts = await this.getAccounts(wid);
 
-      for (const accountIndex of accounts) {
-        const name = await this.getAccountName(wid, accountIndex);
+      for (const name of accounts) {
+        const accountIndex = await this.getAccountIndex(wid, name);
 
-        if (!name)
+        if (!accountIndex)
           continue;
 
         const data = await this.db.get(layout.a.encode(wid, accountIndex));
         assert(data);
 
-        const account = Account.decodeU8(this, data);
-        account.accountIndex = accountIndex;
-        account.name = name;
+        try {
+          const account = Account.decodeU8(this, data);
+          account.accountIndex = accountIndex;
+          account.name = name;
 
-        await this.saveAccount(b, account);
+          await this.saveAccount(b, account);
+          this.logger.info(
+            'migrated lookahead (wid=%d, name=%s)',
+            wid, name);
+        } catch (e) {}
+
       }
     }
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -242,7 +242,7 @@ class WalletDB extends EventEmitter {
       for (const name of accounts) {
         const accountIndex = await this.getAccountIndex(wid, name);
 
-        if (!accountIndex)
+        if (accountIndex < 0)
           continue;
 
         const data = await this.db.get(layout.a.encode(wid, accountIndex));
@@ -676,13 +676,6 @@ class WalletDB extends EventEmitter {
             let newLookahead = Math.max(changeDepth, receiveDepth);
             newLookahead = Math.max(newLookahead, lookahead + 20);
             newLookahead = Math.ceil(newLookahead / 20) * 20;
-
-            console.log({
-              changeDepth,
-              receiveDepth,
-              lookahead,
-              newLookahead,
-            });
             await wallet.setLookahead(accountName, newLookahead);
           }
         }

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -80,6 +80,7 @@ class WalletDB extends EventEmitter {
 
     // Address and outpoint filter.
     this.filter = new BloomFilter();
+    this.filterUpdated = false;
 
     this.init();
   }
@@ -195,6 +196,8 @@ class WalletDB extends EventEmitter {
       this.state.height,
       this.state.startHeight);
 
+    await this.migrateChange();
+
     const wallet = await this.ensure({
       id: 'primary'
     });
@@ -206,9 +209,6 @@ class WalletDB extends EventEmitter {
       wallet.id, wallet.wid, addr.toString(this.network));
 
     this.primary = wallet;
-
-    await this.migrateChange();
-    await this.migrateLookahead();
   }
 
   /**
@@ -652,12 +652,43 @@ class WalletDB extends EventEmitter {
    * @returns {Promise}
    */
 
-  syncFilter() {
+  async syncFilter() {
+    const height = this.state.height;
     this.logger.info('Sending filter to server (%dmb).',
       this.filter.size / 8 / (1 << 20));
 
     this.filterSent = true;
-    return this.client.setFilter(this.filter);
+    this.filterUpdated = false;
+
+    const wallets = await this.getWallets();
+
+    for (let wid of wallets) {
+      const wallet = await this.get(wid);
+      if (wallet) {
+        const accounts = await wallet.getAccounts();
+        for (let accountName of accounts) {
+          const account = await wallet.getAccount(accountName);
+          const {changeDepth, receiveDepth, lookahead} = account.format();
+
+          if (lookahead < changeDepth || lookahead < receiveDepth) {
+            let newLookahead = Math.max(changeDepth, receiveDepth);
+            newLookahead = Math.max(newLookahead, lookahead + 20);
+            newLookahead = Math.ceil(newLookahead / 20) * 20;
+
+            console.log({
+              changeDepth,
+              receiveDepth,
+              lookahead,
+              newLookahead,
+            });
+            await wallet.setLookahead(accountName, newLookahead);
+          }
+        }
+      }
+    }
+
+
+    return this.client.setFilter(this.filter, height);
   }
 
   /**
@@ -2207,6 +2238,12 @@ class WalletDB extends EventEmitter {
           total += 1;
       }
 
+      // Make sure to update the filter with the node
+      // server and the p2p network.
+      if (this.filterUpdated) {
+        await this.syncFilter();
+      }
+
       // Sync the state to the new tip.
       await this.setTip(tip);
     } finally {
@@ -2364,11 +2401,17 @@ class WalletDB extends EventEmitter {
 
       assert(wallet);
 
-      if (await wallet.add(tx, block)) {
+      const {details, derived} = await wallet.add(tx, block);
+
+      if (details) {
         this.logger.info(
           'Added transaction to wallet in WalletDB: %s (%d).',
           wallet.id, wid);
         result = true;
+      }
+
+      if (derived.length > 0) {
+        this.filterUpdated = true;
       }
     }
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -208,6 +208,55 @@ class WalletDB extends EventEmitter {
     this.primary = wallet;
 
     await this.migrateChange();
+    await this.migrateLookahead();
+  }
+
+  /**
+   * Run change address migration.
+   * @param {Wallet} wallet
+   */
+
+  async migrateLookahead() {
+    if (this.options.memory)
+      return;
+
+    if (await this.db.has(layout.M.encode(1)))
+      return;
+
+    const b = this.db.batch();
+
+    b.put(layout.M.encode(1), null);
+
+    this.logger.warning('Checking change address corruption...');
+
+    const wids = await this.db.keys({
+      gte: layout.W.min(),
+      lte: layout.W.max(),
+      parse: key => layout.W.decode(key)[0]
+    });
+
+    for (const wid of wids) {
+      const accounts = await this.getAccounts(wid);
+
+      for (const accountIndex of accounts) {
+        const name = await this.getAccountName(wid, accountIndex);
+
+        if (!name)
+          continue;
+
+        const data = await this.db.get(layout.a.encode(wid, accountIndex));
+        assert(data);
+
+        const account = Account.decodeU8(this, data);
+        account.accountIndex = accountIndex;
+        account.name = name;
+
+        await this.saveAccount(b, account);
+      }
+    }
+
+    if (this.options.migrate === 1)
+      await b.write();
   }
 
   /**


### PR DESCRIPTION
- migrate lookahead from uint8 to uint32
- during rescan, increment lookahead value by 20 if new depth exceeds existing lookahead value
- during rescan, when lookahead is increased, sync new filter to backend (`node/http`)
- during rescan, when new filter is received, stop current rescan and start a new one with the new filter, and at the height of which the filter was updated